### PR TITLE
Feat/workhours

### DIFF
--- a/src/components/EntryCard.tsx
+++ b/src/components/EntryCard.tsx
@@ -14,10 +14,21 @@ function EntryCard({ entry, onEdit, onDelete }: EntryCardProps) {
     }
   };
 
+  const formatTime = (time: string) => {
+    if (!time) return "";
+    const [hours, minutes] = time.split(":").map(Number);
+    const period = hours >= 12 ? "PM" : "AM";
+    const adjustedHours = hours % 12 || 12;
+    return `${adjustedHours}:${minutes.toString().padStart(2, "0")} ${period}`;
+  };
+
   return (
     <div className="entry-card">
       <div className="entry-header">
         <div className="entry-date">{entry.date}</div>
+        <div className="entry-date">
+          {formatTime(entry.startTime)} - {formatTime(entry.endTime)}
+        </div>
         <div className="entry-hours">{entry.hours}h</div>
       </div>
 

--- a/src/components/EntryForm.css
+++ b/src/components/EntryForm.css
@@ -71,6 +71,19 @@
   margin-top: 8px;
 }
 
+.form-time-inputs {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.form-time-inputs input {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
 .btn {
   padding: 10px 20px;
   border: none;

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { TimeEntry } from "../types";
 import { generateId } from "../utils/dateUtils";
 import "./EntryForm.css";
@@ -10,20 +10,59 @@ interface EntryFormProps {
 }
 
 function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
-  const [date, setDate] = useState(initialEntry?.date || new Date().toISOString().split("T")[0]);
+  const [date, setDate] = useState(
+    initialEntry?.date || new Date().toISOString().split("T")[0]
+  );
   const [hours, setHours] = useState(initialEntry?.hours?.toString() || "");
+  const [startTime, setStartTime] = useState(
+    initialEntry?.startTime || new Date().toTimeString().slice(0, 5)
+  );
+  const [endTime, setEndTime] = useState(initialEntry?.endTime || "");
   const [task, setTask] = useState(initialEntry?.task || "");
+
+  // Sync: hours → endTime
+  useEffect(() => {
+    if (!hours) {
+      setEndTime("");
+      return;
+    }
+    if (!isNaN(Number(hours))) {
+      const start = new Date(`${date}T${startTime}`);
+      const newEnd = new Date(start.getTime() + Number(hours) * 60 * 60 * 1000);
+      setEndTime(newEnd.toTimeString().slice(0, 5));
+    }
+  }, [hours, startTime, date, endTime]);
+
+  // Sync: endTime → hours
+  useEffect(() => {
+    if (!endTime) {
+      setHours("");
+      return;
+    }
+
+    const start = new Date(`${date}T${startTime}`);
+    const end = new Date(`${date}T${endTime}`);
+
+    if (end < start) {
+      end.setDate(end.getDate() + 1);
+    }
+
+    const diff = (end.getTime() - start.getTime()) / (1000 * 60 * 60);
+    if (!isNaN(diff)) {
+      setHours(diff.toFixed(1));
+    }
+  }, [endTime, startTime, date]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!date || !hours || !task) {
+    if (!date || !hours || !startTime || !endTime || !task) {
       alert("Please fill in all fields");
       return;
     }
 
     const hoursNum = parseFloat(hours);
-    if (isNaN(hoursNum) || hoursNum <= 0) {
+    if (isNaN(hoursNum) || hoursNum <= 0 || hoursNum > 24) {
       alert("Please enter valid hours");
       return;
     }
@@ -32,9 +71,11 @@ function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
       id: initialEntry?.id || generateId(),
       date,
       hours: hoursNum,
+      startTime,
+      endTime,
       task,
     };
-
+    console.log("Submitting entry:", entry);
     onSubmit(entry);
   };
 
@@ -61,11 +102,39 @@ function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
               id="hours"
               value={hours}
               onChange={(e) => setHours(e.target.value)}
+              onBlur={() => {
+                if (!isNaN(Number(hours)) && hours !== "") {
+                  setHours(Number(hours).toFixed(1));
+                }
+              }}
               min="0.1"
               step="0.1"
               placeholder="e.g., 8.5"
               required
             />
+          </div>
+
+          <div className="form-group">
+            <div className="form-time-inputs">
+              <label htmlFor="startTime">Start Time:</label>
+              <input
+                type="time"
+                id="startTime"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                required
+              />
+              <label htmlFor="endTime">End Time:</label>
+              <input
+                type="time"
+                id="endTime"
+                value={endTime}
+                onChange={(e) => {
+                  setEndTime(e.target.value);
+                }}
+                required
+              />
+            </div>
           </div>
 
           <div className="form-group">
@@ -84,7 +153,11 @@ function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
             <button type="submit" className="btn btn-primary">
               {initialEntry ? "Update Entry" : "Add Entry"}
             </button>
-            <button type="button" onClick={onCancel} className="btn btn-secondary">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="btn btn-secondary"
+            >
               Cancel
             </button>
           </div>

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { TimeEntry } from "../types";
 import { generateId } from "../utils/dateUtils";
 import "./EntryForm.css";
@@ -20,22 +20,12 @@ function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
   const [endTime, setEndTime] = useState(initialEntry?.endTime || "");
   const [task, setTask] = useState(initialEntry?.task || "");
 
-  // Sync: hours → endTime
-  useEffect(() => {
-    if (!hours) {
-      setEndTime("");
-      return;
-    }
-    if (!isNaN(Number(hours))) {
-      const start = new Date(`${date}T${startTime}`);
-      const newEnd = new Date(start.getTime() + Number(hours) * 60 * 60 * 1000);
-      setEndTime(newEnd.toTimeString().slice(0, 5));
-    }
-  }, [hours, startTime, date, endTime]);
+  const lastChanged = useRef<"hours" | "endTime" | null>(null);
 
-  // Sync: endTime → hours
   useEffect(() => {
-    if (!endTime) {
+    if (lastChanged.current === "hours") return;
+
+    if (!startTime || !endTime) {
       setHours("");
       return;
     }
@@ -51,7 +41,17 @@ function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
     if (!isNaN(diff)) {
       setHours(diff.toFixed(1));
     }
-  }, [endTime, startTime, date]);
+  }, [startTime, endTime, date]);
+
+  useEffect(() => {
+    if (lastChanged.current !== "hours") return;
+
+    if (!hours || isNaN(Number(hours))) return;
+
+    const start = new Date(`${date}T${startTime}`);
+    const newEnd = new Date(start.getTime() + Number(hours) * 60 * 60 * 1000);
+    setEndTime(newEnd.toTimeString().slice(0, 5));
+  }, [hours, startTime, date]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -101,7 +101,10 @@ function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
               type="number"
               id="hours"
               value={hours}
-              onChange={(e) => setHours(e.target.value)}
+              onChange={(e) => {
+                setHours(e.target.value);
+                lastChanged.current = "hours";
+              }}
               onBlur={() => {
                 if (!isNaN(Number(hours)) && hours !== "") {
                   setHours(Number(hours).toFixed(1));
@@ -121,7 +124,10 @@ function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
                 type="time"
                 id="startTime"
                 value={startTime}
-                onChange={(e) => setStartTime(e.target.value)}
+                onChange={(e) => {
+                  setStartTime(e.target.value);
+                  lastChanged.current = "endTime";
+                }}
                 required
               />
               <label htmlFor="endTime">End Time:</label>
@@ -131,6 +137,7 @@ function EntryForm({ onSubmit, onCancel, initialEntry }: EntryFormProps) {
                 value={endTime}
                 onChange={(e) => {
                   setEndTime(e.target.value);
+                  lastChanged.current = "endTime";
                 }}
                 required
               />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,8 @@
 export interface TimeEntry {
   id: string;
   date: string; // YYYY-MM-DD format
+  startTime: string; // HH:MM format (24-hour)
+  endTime: string; // HH:MM format (24-hour)
   hours: number;
   task: string;
 }


### PR DESCRIPTION
- Implemented start and end time fields in the new entry form, with the start time defaulting to the current time and the hours/end time fields synchronized.
- Updated the entry card to display start and end times in a 12-hour format.

<img width="398" height="381" alt="Screenshot 2025-08-08 130722" src="https://github.com/user-attachments/assets/815f34b8-4b60-4531-b665-7518b555b5e0" />
<img width="702" height="154" alt="Screenshot 2025-08-08 131030" src="https://github.com/user-attachments/assets/47ee87db-5b69-4d43-a1f0-70b5db69ef70" />
